### PR TITLE
fix(app): tx result must be always succeeded in `FinalizeBlock`

### DIFF
--- a/app/abci.go
+++ b/app/abci.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/omni-network/omni/lib/errors"
+
 	sdklog "cosmossdk.io/log"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -124,9 +126,10 @@ func (a ABCIWrappedApplication) FinalizeBlock(req *abci.RequestFinalizeBlock) (*
 		logger.Error("FinalizeBlock contains unexpected failed transaction [BUG]",
 			"info", res.Info, "code", res.Code, "log", res.Log,
 			"code_space", res.Codespace, "index", i, "height", req.Height)
+		return resp, errors.New("FinalizeBlock contains unexpected failed transaction [BUG]")
 	}
 
-	return resp, err
+	return resp, nil
 }
 
 func (a ABCIWrappedApplication) ExtendVote(ctx context.Context, vote *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {


### PR DESCRIPTION
`x/evmengine`'s msg server logic is so critical. So, we should not ignore the error if it happens.
If we ignore the error, the state could be corrupted.
So, we should halt the chain if If tx result means failure in `FinalizeBlock`.

# Before

### Mitosisd
`missing payload ID [BUG]` error happens:
![image](https://github.com/user-attachments/assets/14a7831f-0f3c-4aa1-bd1a-c90e59af75af)

### Geth
```
INFO [03-24|06:41:59.008] Chain head was updated                   number=85 hash=070477..22e9a5 root=d9ce07..642c0b elapsed="69.042µs"
INFO [03-24|06:41:59.012] Starting work on payload                 id=0x03134dbe220156b3
INFO [03-24|06:41:59.012] Updated payload                          id=0x03134dbe220156b3 number=86 hash=9fef9c..14e8d0 txs=0 withdrawals=0 gas=0         fees=0               root=d9ce07..642c0b elapsed="118.958µs"
INFO [03-24|06:42:00.007] Stopping work on payload                 id=0x03134dbe220156b3 reason=delivery
INFO [03-24|06:42:00.030] Imported new potential chain segment     number=86 hash=9fef9c..14e8d0 blocks=1 txs=0 mgas=0.000 elapsed="299.583µs" mgasps=0.000    snapdiffs=1.65KiB triedirty=0.00B
WARN [03-24|06:42:00.037] Ignoring already known beacon payload    number=86 hash=9fef9c..14e8d0 age=3s
INFO [03-24|06:42:00.038] Chain head was updated                   number=86 hash=9fef9c..14e8d0 root=d9ce07..642c0b elapsed="39.125µs"
INFO [03-24|06:42:00.039] Starting work on payload                 id=0x035a3f1f81815e4d
INFO [03-24|06:42:00.040] Updated payload                          id=0x035a3f1f81815e4d number=87 hash=329b32..7d89da txs=1 withdrawals=0 gas=29890     fees=2.988972095e-05 root=718143..0255f3 elapsed="173.75µs"
INFO [03-24|06:42:01.038] Stopping work on payload                 id=0x035a3f1f81815e4d reason=delivery
INFO [03-24|06:42:01.049] Imported new potential chain segment     number=87 hash=329b32..7d89da blocks=1 txs=1 mgas=0.030 elapsed="846.5µs"   mgasps=35.310   snapdiffs=1.74KiB triedirty=0.00B
WARN [03-24|06:42:01.063] Ignoring already known beacon payload    number=87 hash=329b32..7d89da age=2s
INFO [03-24|06:42:01.064] Chain head was updated                   number=87 hash=329b32..7d89da root=718143..0255f3 elapsed="147.375µs"
INFO [03-24|06:42:01.068] Ignoring beacon update to old head       number=86 hash=9fef9c..14e8d0 age=4s      have=87
INFO [03-24|06:42:02.062] Ignoring beacon update to old head       number=86 hash=9fef9c..14e8d0 age=5s      have=87
INFO [03-24|06:42:02.090] Ignoring beacon update to old head       number=86 hash=9fef9c..14e8d0 age=5s      have=87
INFO [03-24|06:42:03.088] Ignoring beacon update to old head       number=86 hash=9fef9c..14e8d0 age=6s      have=87
INFO [03-24|06:42:03.102] Ignoring beacon update to old head       number=86 hash=9fef9c..14e8d0 age=6s      have=87
INFO [03-24|06:42:04.102] Ignoring beacon update to old head       number=86 hash=9fef9c..14e8d0 age=7s      have=87
```


# After

![image](https://github.com/user-attachments/assets/479f7a14-d7f9-4200-b1a8-bac92b942862)

