### PR TITLE
fix(app): use proper `MaxWithdrawalsPerBlock` for `x/evmengine` to prevent potential issues

### DIFF
--- a/app/app_config.go
+++ b/app/app_config.go
@@ -151,10 +151,8 @@ var (
 			{
 				Name: evmengtypes.ModuleName,
 				Config: appconfig.WrapAny(&evmengmodule.Module{
-					Authority: evmgovtypes.ModuleName,
-					// NOTE: 0 means no limit.
-					// It is okay because it is also limited by WithdrawalLimit in the evmvalidator module.
-					MaxWithdrawalsPerBlock: 0,
+					Authority:              evmgovtypes.ModuleName,
+					MaxWithdrawalsPerBlock: 32,
 				}),
 			},
 			{


### PR DESCRIPTION
Practically, there would be no issue even if we set `MaxWithdrawalsPerBlock` to 0 because fallback logic in event procedures would not actually be called. We already have proper verification logic on the contract side (`ValidatorManager.sol`), so `registerValidator` and `depositCollateral` would always succeed.

However, setting `MaxWithdrawalsPerBlock` properly would be better practice and prevent potential issues. Therefore, I will set `MaxWithdrawalsPerBlock` to 32.
I don't think it would be a problem if we use different values for `MaxWithdrawalsPerBlock` and `WithdrawalLimit`. I will use a hard-coded value (32) for `MaxWithdrawalsPerBlock`, while `WithdrawalLimit` will be managed in evmvalidator's parameters. We might use a value less than or equal to 32 for the `WithdrawalLimit`, so hard-coding `MaxWithdrawalsPerBlock` should not be an issue.