### PR TITLE
fix(ci): update test coverage reporting in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,11 @@ jobs:
 
       - name: Run tests
         run: |
-          go test -v -race -coverprofile=coverage.out ./...
+          go test -v -race -coverprofile=coverage.txt ./...
 
       - name: Generate test coverage report
         run: |
-          go tool cover -html=coverage.out -o coverage.html
+          go tool cover -html=coverage.txt -o coverage.html
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4
@@ -43,24 +43,9 @@ jobs:
           name: coverage-report
           path: coverage.html
 
-      # Commented out strict coverage check - now using Codecov for coverage reporting
-      # - name: Check test coverage
-      #   if: matrix.go-version == '1.21'
-      #   run: |
-      #     COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
-      #     echo "Total test coverage: ${COVERAGE}%"
-      #     if (( $(echo "$COVERAGE < 60" | bc -l) )); then
-      #       echo "❌ Test coverage is below 60%"
-      #       exit 1
-      #     else
-      #       echo "✅ Test coverage is above 60%"
-      #     fi
-
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.out
-          flags: unittests
-          name: codecov-umbrella
+          slug: ${{ github.repository }}
           fail_ci_if_error: false 


### PR DESCRIPTION
- Changed coverage output file from `coverage.out` to `coverage.txt` for consistency.
- Updated the coverage report generation command to reflect the new output file.
- Upgraded Codecov action from v4 to v5 and adjusted parameters for improved functionality.
- Removed commented-out coverage check to streamline the workflow.
