### PR TITLE
chore(ci): upgrade GitHub Actions artifact management to v4

### DIFF
--- a/.github/workflows/release-mito.yml
+++ b/.github/workflows/release-mito.yml
@@ -52,7 +52,7 @@ jobs:
           done
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries-mito-${{ matrix.os }}-${{ matrix.arch }}
           path: build/*
@@ -74,7 +74,7 @@ jobs:
           echo "VERSION=${TAG_NAME#mito/}" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/release-mitosisd.yml
+++ b/.github/workflows/release-mitosisd.yml
@@ -53,7 +53,7 @@ jobs:
           done
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: binaries-mitosisd-${{ matrix.os }}-${{ matrix.arch }}
           path: build/*
@@ -75,7 +75,7 @@ jobs:
           echo "VERSION=${TAG_NAME}" >> $GITHUB_OUTPUT
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 


### PR DESCRIPTION
- Updated the `upload-artifact` and `download-artifact` actions in `release-mito.yml` and `release-mitosisd.yml` workflows from v3 to v4 for improved functionality and performance.
