### PR TITLE
docs: correct developer docs URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ chain/
 
 ## 📚 Additional Resources
 
-- [Mitosis Developer Docs](https://docs.mitosis.org/developers/)
+- [Mitosis Developer Docs](https://docs.mitosis.org/docs/developers/overview)
 - [Cosmos SDK Documentation](https://docs.cosmos.network/)
 
 ---

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ If you have any questions:
 
 - Open a discussion with your question, or
 - Open an issue with the bug
-- Check our [developer docs](https://docs.mitosis.org/developers/)
+- Check our [developer docs](https://docs.mitosis.org/docs/developers/overview)
 
 ## Security
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -202,7 +202,7 @@ main() {
     fi
 
     echo
-    log "📖 Documentation: https://docs.mitosis.org/developers/"
+    log "📖 Documentation: https://docs.mitosis.org/docs/developers/overview"
     log "💬 Community: https://discord.gg/mitosis"
 
     # Show installation info for other component


### PR DESCRIPTION
Hi, I noticed that some of the developer documentation links in this repository had errors (e.g. incorrect URLs or typos).

This pull request fixes those links in `install.sh`, `README.md`, and `CONTRIBUTING.md` to ensure they point to the correct destination.

Apologies if this is a small contribution — I just wanted to help clean it up a bit.  
Please let me know if anything should be changed. Thank you!