### PR TITLE
feat(cmd/mitosisd): add Ethereum genesis file generation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -161,6 +161,7 @@ issues:
     - ".*\\.pb\\.go$" # Ignore generated protobuf files
     - ".*\\.pulsar\\.go$" # Ignore generated protobuf files
     - "bindings/*" # Ignore generated contract bindings
+    - "tmp/*" # Ignore temporary files directory
 
   exclude-rules:
     - source: "^//\\s*go:generate\\s"

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ golangci_version=v1.64.8
 lint:
 	@echo "--> Running linter"
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golangci_version)
-	@$(golangci_lint_cmd) run --timeout=10m
+	@$(golangci_lint_cmd) run --timeout=10m ./api/... ./app/... ./cmd/... ./types/... ./x/...
 
 lint-fix:
 	@echo "--> Running linter"

--- a/cmd/mitosisd/cmd/eth_genesis.go
+++ b/cmd/mitosisd/cmd/eth_genesis.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 )
 
+// DefaultFundedAddress is the default Ethereum address that receives initial funding
+const DefaultFundedAddress = "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
+
 // EthereumChainConfig represents the chain configuration for Ethereum genesis
 type EthereumChainConfig struct {
 	ChainID                 *big.Int `json:"chainId"`
@@ -92,7 +95,7 @@ func GenerateEthereumGenesis(chainID string, outputPath string) error {
 	}
 
 	// Default funded address (same as in existing genesis files)
-	defaultFundedAddress := "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
+	defaultFundedAddress := DefaultFundedAddress
 
 	// Initial balance: 10,000,000 ETH for localnet
 	initialBalance := "10000000000000000000000000"
@@ -125,12 +128,12 @@ func GenerateEthereumGenesis(chainID string, outputPath string) error {
 
 	// Ensure the directory exists
 	dir := filepath.Dir(outputPath)
-	if err := os.MkdirAll(dir, 0750); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 
 	// Write the genesis file
-	if err := os.WriteFile(outputPath, jsonData, 0600); err != nil {
+	if err := os.WriteFile(outputPath, jsonData, 0o600); err != nil {
 		return fmt.Errorf("failed to write ethereum genesis file: %w", err)
 	}
 

--- a/cmd/mitosisd/cmd/eth_genesis.go
+++ b/cmd/mitosisd/cmd/eth_genesis.go
@@ -125,7 +125,7 @@ func GenerateEthereumGenesis(chainID string, outputPath string) error {
 
 	// Ensure the directory exists
 	dir := filepath.Dir(outputPath)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0750); err != nil {
 		return fmt.Errorf("failed to create directory %s: %w", dir, err)
 	}
 

--- a/cmd/mitosisd/cmd/eth_genesis.go
+++ b/cmd/mitosisd/cmd/eth_genesis.go
@@ -34,14 +34,14 @@ type EthereumChainConfig struct {
 
 // EthereumGenesisSpec represents the Ethereum genesis specification
 type EthereumGenesisSpec struct {
-	Config     *EthereumChainConfig       `json:"config"`
-	Nonce      string                     `json:"nonce"`
-	Timestamp  string                     `json:"timestamp"`
-	ExtraData  string                     `json:"extraData"`
-	GasLimit   string                     `json:"gasLimit"`
-	Difficulty string                     `json:"difficulty"`
-	MixHash    string                     `json:"mixHash"`
-	Coinbase   string                     `json:"coinbase"`
+	Config     *EthereumChainConfig        `json:"config"`
+	Nonce      string                      `json:"nonce"`
+	Timestamp  string                      `json:"timestamp"`
+	ExtraData  string                      `json:"extraData"`
+	GasLimit   string                      `json:"gasLimit"`
+	Difficulty string                      `json:"difficulty"`
+	MixHash    string                      `json:"mixHash"`
+	Coinbase   string                      `json:"coinbase"`
 	Alloc      map[string]AllocatedAccount `json:"alloc"`
 }
 
@@ -68,11 +68,11 @@ func GetEthChainIDFromCosmosChainID(cosmosChainID string) *big.Int {
 // GenerateEthereumGenesis creates an Ethereum genesis file
 func GenerateEthereumGenesis(chainID string, outputPath string) error {
 	ethChainID := GetEthChainIDFromCosmosChainID(chainID)
-	
+
 	// Create chain config with all EIPs enabled from genesis (similar to existing configs)
 	zero := big.NewInt(0)
 	zeroTime := uint64(0)
-	
+
 	chainConfig := &EthereumChainConfig{
 		ChainID:                 ethChainID,
 		HomesteadBlock:          zero,
@@ -93,7 +93,7 @@ func GenerateEthereumGenesis(chainID string, outputPath string) error {
 
 	// Default funded address (same as in existing genesis files)
 	defaultFundedAddress := "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
-	
+
 	// Initial balance: 10,000,000 ETH for localnet
 	initialBalance := "10000000000000000000000000"
 	if chainID == "mitosis-devnet-1" {

--- a/cmd/mitosisd/cmd/eth_genesis.go
+++ b/cmd/mitosisd/cmd/eth_genesis.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"path/filepath"
+)
+
+// EthereumChainConfig represents the chain configuration for Ethereum genesis
+type EthereumChainConfig struct {
+	ChainID                 *big.Int `json:"chainId"`
+	HomesteadBlock          *big.Int `json:"homesteadBlock"`
+	DAOForkBlock            *big.Int `json:"daoForkBlock,omitempty"`
+	DAOForkSupport          bool     `json:"daoForkSupport,omitempty"`
+	EIP150Block             *big.Int `json:"eip150Block"`
+	EIP155Block             *big.Int `json:"eip155Block"`
+	EIP158Block             *big.Int `json:"eip158Block"`
+	ByzantiumBlock          *big.Int `json:"byzantiumBlock"`
+	ConstantinopleBlock     *big.Int `json:"constantinopleBlock"`
+	PetersburgBlock         *big.Int `json:"petersburgBlock"`
+	IstanbulBlock           *big.Int `json:"istanbulBlock"`
+	BerlinBlock             *big.Int `json:"berlinBlock"`
+	LondonBlock             *big.Int `json:"londonBlock"`
+	ArrowGlacierBlock       *big.Int `json:"arrowGlacierBlock,omitempty"`
+	GrayGlacierBlock        *big.Int `json:"grayGlacierBlock,omitempty"`
+	MergeNetsplitBlock      *big.Int `json:"mergeNetsplitBlock,omitempty"`
+	TerminalTotalDifficulty *big.Int `json:"terminalTotalDifficulty"`
+	ShanghaiTime            *uint64  `json:"shanghaiTime"`
+	CancunTime              *uint64  `json:"cancunTime"`
+	PragueTime              *uint64  `json:"pragueTime,omitempty"`
+}
+
+// EthereumGenesisSpec represents the Ethereum genesis specification
+type EthereumGenesisSpec struct {
+	Config     *EthereumChainConfig       `json:"config"`
+	Nonce      string                     `json:"nonce"`
+	Timestamp  string                     `json:"timestamp"`
+	ExtraData  string                     `json:"extraData"`
+	GasLimit   string                     `json:"gasLimit"`
+	Difficulty string                     `json:"difficulty"`
+	MixHash    string                     `json:"mixHash"`
+	Coinbase   string                     `json:"coinbase"`
+	Alloc      map[string]AllocatedAccount `json:"alloc"`
+}
+
+// AllocatedAccount represents a pre-funded account in the genesis
+type AllocatedAccount struct {
+	Balance string `json:"balance"`
+}
+
+// GetEthChainIDFromCosmosChainID derives the Ethereum chain ID from Cosmos chain ID
+func GetEthChainIDFromCosmosChainID(cosmosChainID string) *big.Int {
+	// Default mappings based on existing configuration
+	switch cosmosChainID {
+	case "mitosis-localnet-1":
+		return big.NewInt(124899)
+	case "mitosis-devnet-1":
+		return big.NewInt(124864)
+	default:
+		// For custom chains, use a deterministic derivation
+		// This is a simple hash-based approach - you may want to customize this
+		return big.NewInt(100000)
+	}
+}
+
+// GenerateEthereumGenesis creates an Ethereum genesis file
+func GenerateEthereumGenesis(chainID string, outputPath string) error {
+	ethChainID := GetEthChainIDFromCosmosChainID(chainID)
+	
+	// Create chain config with all EIPs enabled from genesis (similar to existing configs)
+	zero := big.NewInt(0)
+	zeroTime := uint64(0)
+	
+	chainConfig := &EthereumChainConfig{
+		ChainID:                 ethChainID,
+		HomesteadBlock:          zero,
+		EIP150Block:             zero,
+		EIP155Block:             zero,
+		EIP158Block:             zero,
+		ByzantiumBlock:          zero,
+		ConstantinopleBlock:     zero,
+		PetersburgBlock:         zero,
+		IstanbulBlock:           zero,
+		BerlinBlock:             zero,
+		LondonBlock:             zero,
+		TerminalTotalDifficulty: zero,
+		ShanghaiTime:            &zeroTime,
+		CancunTime:              &zeroTime,
+		PragueTime:              &zeroTime,
+	}
+
+	// Default funded address (same as in existing genesis files)
+	defaultFundedAddress := "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
+	
+	// Initial balance: 10,000,000 ETH for localnet
+	initialBalance := "10000000000000000000000000"
+	if chainID == "mitosis-devnet-1" {
+		// 999,000,000 ETH for devnet
+		initialBalance = "999000000000000000000000000"
+	}
+
+	genesis := &EthereumGenesisSpec{
+		Config:     chainConfig,
+		Nonce:      "0x0",
+		Timestamp:  "0x0",
+		ExtraData:  "0x",
+		GasLimit:   "0x1c9c380", // 30,000,000 gas limit
+		Difficulty: "0x0",       // PoS from start
+		MixHash:    "0x0000000000000000000000000000000000000000000000000000000000000000",
+		Coinbase:   "0x0000000000000000000000000000000000000000",
+		Alloc: map[string]AllocatedAccount{
+			defaultFundedAddress: {
+				Balance: initialBalance,
+			},
+		},
+	}
+
+	// Marshal to JSON with proper formatting
+	jsonData, err := json.MarshalIndent(genesis, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal ethereum genesis: %w", err)
+	}
+
+	// Ensure the directory exists
+	dir := filepath.Dir(outputPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	// Write the genesis file
+	if err := os.WriteFile(outputPath, jsonData, 0600); err != nil {
+		return fmt.Errorf("failed to write ethereum genesis file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/mitosisd/cmd/eth_genesis_test.go
+++ b/cmd/mitosisd/cmd/eth_genesis_test.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"encoding/json"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetEthChainIDFromCosmosChainID(t *testing.T) {
+	tests := []struct {
+		name           string
+		cosmosChainID  string
+		expectedChainID *big.Int
+	}{
+		{
+			name:           "localnet chain ID",
+			cosmosChainID:  "mitosis-localnet-1",
+			expectedChainID: big.NewInt(124899),
+		},
+		{
+			name:           "devnet chain ID",
+			cosmosChainID:  "mitosis-devnet-1",
+			expectedChainID: big.NewInt(124864),
+		},
+		{
+			name:           "custom chain ID",
+			cosmosChainID:  "custom-chain-123",
+			expectedChainID: big.NewInt(100000),
+		},
+		{
+			name:           "empty chain ID",
+			cosmosChainID:  "",
+			expectedChainID: big.NewInt(100000),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetEthChainIDFromCosmosChainID(tt.cosmosChainID)
+			assert.Equal(t, tt.expectedChainID, result)
+		})
+	}
+}
+
+func TestGenerateEthereumGenesis(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name               string
+		chainID            string
+		outputPath         string
+		expectedBalance    string
+		expectedChainID    *big.Int
+		expectError        bool
+		validateGenesis    func(t *testing.T, genesis *EthereumGenesisSpec)
+	}{
+		{
+			name:            "generate localnet genesis",
+			chainID:         "mitosis-localnet-1",
+			outputPath:      filepath.Join(tempDir, "localnet", "genesis.json"),
+			expectedBalance: "10000000000000000000000000",
+			expectedChainID: big.NewInt(124899),
+			expectError:     false,
+			validateGenesis: func(t *testing.T, genesis *EthereumGenesisSpec) {
+				// Validate chain config
+				assert.Equal(t, big.NewInt(124899), genesis.Config.ChainID)
+				assert.Equal(t, big.NewInt(0), genesis.Config.HomesteadBlock)
+				assert.Equal(t, big.NewInt(0), genesis.Config.ByzantiumBlock)
+				assert.Equal(t, big.NewInt(0), genesis.Config.LondonBlock)
+				assert.NotNil(t, genesis.Config.ShanghaiTime)
+				assert.Equal(t, uint64(0), *genesis.Config.ShanghaiTime)
+				assert.NotNil(t, genesis.Config.CancunTime)
+				assert.Equal(t, uint64(0), *genesis.Config.CancunTime)
+				
+				// Validate genesis parameters
+				assert.Equal(t, "0x0", genesis.Nonce)
+				assert.Equal(t, "0x0", genesis.Timestamp)
+				assert.Equal(t, "0x1c9c380", genesis.GasLimit)
+				assert.Equal(t, "0x0", genesis.Difficulty)
+				
+				// Validate alloc
+				fundedAddr := "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
+				account, exists := genesis.Alloc[fundedAddr]
+				assert.True(t, exists)
+				assert.Equal(t, "10000000000000000000000000", account.Balance)
+			},
+		},
+		{
+			name:            "generate devnet genesis",
+			chainID:         "mitosis-devnet-1",
+			outputPath:      filepath.Join(tempDir, "devnet", "genesis.json"),
+			expectedBalance: "999000000000000000000000000",
+			expectedChainID: big.NewInt(124864),
+			expectError:     false,
+			validateGenesis: func(t *testing.T, genesis *EthereumGenesisSpec) {
+				// Validate chain ID
+				assert.Equal(t, big.NewInt(124864), genesis.Config.ChainID)
+				
+				// Validate devnet specific balance
+				fundedAddr := "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
+				account, exists := genesis.Alloc[fundedAddr]
+				assert.True(t, exists)
+				assert.Equal(t, "999000000000000000000000000", account.Balance)
+			},
+		},
+		{
+			name:            "generate custom chain genesis",
+			chainID:         "custom-test-chain",
+			outputPath:      filepath.Join(tempDir, "custom", "genesis.json"),
+			expectedBalance: "10000000000000000000000000",
+			expectedChainID: big.NewInt(100000),
+			expectError:     false,
+			validateGenesis: func(t *testing.T, genesis *EthereumGenesisSpec) {
+				// Validate custom chain ID
+				assert.Equal(t, big.NewInt(100000), genesis.Config.ChainID)
+			},
+		},
+		{
+			name:        "invalid output path",
+			chainID:     "mitosis-localnet-1",
+			outputPath:  "/invalid\x00path/genesis.json",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GenerateEthereumGenesis(tt.chainID, tt.outputPath)
+
+			if tt.expectError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Verify file exists
+			_, err = os.Stat(tt.outputPath)
+			require.NoError(t, err)
+
+			// Read and parse the generated file
+			data, err := os.ReadFile(tt.outputPath)
+			require.NoError(t, err)
+
+			var genesis EthereumGenesisSpec
+			err = json.Unmarshal(data, &genesis)
+			require.NoError(t, err)
+
+			// Run custom validation if provided
+			if tt.validateGenesis != nil {
+				tt.validateGenesis(t, &genesis)
+			}
+		})
+	}
+}
+
+func TestEthereumChainConfig_AllFields(t *testing.T) {
+	// Test that all chain config fields are properly set
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "test_genesis.json")
+
+	err := GenerateEthereumGenesis("test-chain", outputPath)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	var genesis EthereumGenesisSpec
+	err = json.Unmarshal(data, &genesis)
+	require.NoError(t, err)
+
+	config := genesis.Config
+
+	// Verify all required blocks are set to 0
+	assert.Equal(t, big.NewInt(0), config.HomesteadBlock)
+	assert.Equal(t, big.NewInt(0), config.EIP150Block)
+	assert.Equal(t, big.NewInt(0), config.EIP155Block)
+	assert.Equal(t, big.NewInt(0), config.EIP158Block)
+	assert.Equal(t, big.NewInt(0), config.ByzantiumBlock)
+	assert.Equal(t, big.NewInt(0), config.ConstantinopleBlock)
+	assert.Equal(t, big.NewInt(0), config.PetersburgBlock)
+	assert.Equal(t, big.NewInt(0), config.IstanbulBlock)
+	assert.Equal(t, big.NewInt(0), config.BerlinBlock)
+	assert.Equal(t, big.NewInt(0), config.LondonBlock)
+	assert.Equal(t, big.NewInt(0), config.TerminalTotalDifficulty)
+
+	// Verify time-based forks
+	assert.NotNil(t, config.ShanghaiTime)
+	assert.Equal(t, uint64(0), *config.ShanghaiTime)
+	assert.NotNil(t, config.CancunTime)
+	assert.Equal(t, uint64(0), *config.CancunTime)
+	assert.NotNil(t, config.PragueTime)
+	assert.Equal(t, uint64(0), *config.PragueTime)
+
+	// Verify optional fields are nil (not set)
+	assert.Nil(t, config.DAOForkBlock)
+	assert.False(t, config.DAOForkSupport)
+	assert.Nil(t, config.ArrowGlacierBlock)
+	assert.Nil(t, config.GrayGlacierBlock)
+	assert.Nil(t, config.MergeNetsplitBlock)
+}
+
+func TestGenerateEthereumGenesis_DirectoryCreation(t *testing.T) {
+	tempDir := t.TempDir()
+	// Test nested directory creation
+	nestedPath := filepath.Join(tempDir, "a", "b", "c", "genesis.json")
+
+	err := GenerateEthereumGenesis("test-chain", nestedPath)
+	require.NoError(t, err)
+
+	// Verify file exists
+	_, err = os.Stat(nestedPath)
+	require.NoError(t, err)
+}
+
+func TestGenerateEthereumGenesis_JSONFormat(t *testing.T) {
+	tempDir := t.TempDir()
+	outputPath := filepath.Join(tempDir, "genesis.json")
+
+	err := GenerateEthereumGenesis("mitosis-localnet-1", outputPath)
+	require.NoError(t, err)
+
+	// Read the file
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	// Verify it's valid JSON
+	var rawJSON map[string]interface{}
+	err = json.Unmarshal(data, &rawJSON)
+	require.NoError(t, err)
+
+	// Verify proper indentation (should contain newlines and spaces)
+	assert.Contains(t, string(data), "\n")
+	assert.Contains(t, string(data), "  ")
+}

--- a/cmd/mitosisd/cmd/eth_genesis_test.go
+++ b/cmd/mitosisd/cmd/eth_genesis_test.go
@@ -13,28 +13,28 @@ import (
 
 func TestGetEthChainIDFromCosmosChainID(t *testing.T) {
 	tests := []struct {
-		name           string
-		cosmosChainID  string
+		name            string
+		cosmosChainID   string
 		expectedChainID *big.Int
 	}{
 		{
-			name:           "localnet chain ID",
-			cosmosChainID:  "mitosis-localnet-1",
+			name:            "localnet chain ID",
+			cosmosChainID:   "mitosis-localnet-1",
 			expectedChainID: big.NewInt(124899),
 		},
 		{
-			name:           "devnet chain ID",
-			cosmosChainID:  "mitosis-devnet-1",
+			name:            "devnet chain ID",
+			cosmosChainID:   "mitosis-devnet-1",
 			expectedChainID: big.NewInt(124864),
 		},
 		{
-			name:           "custom chain ID",
-			cosmosChainID:  "custom-chain-123",
+			name:            "custom chain ID",
+			cosmosChainID:   "custom-chain-123",
 			expectedChainID: big.NewInt(100000),
 		},
 		{
-			name:           "empty chain ID",
-			cosmosChainID:  "",
+			name:            "empty chain ID",
+			cosmosChainID:   "",
 			expectedChainID: big.NewInt(100000),
 		},
 	}
@@ -51,13 +51,13 @@ func TestGenerateEthereumGenesis(t *testing.T) {
 	tempDir := t.TempDir()
 
 	tests := []struct {
-		name               string
-		chainID            string
-		outputPath         string
-		expectedBalance    string
-		expectedChainID    *big.Int
-		expectError        bool
-		validateGenesis    func(t *testing.T, genesis *EthereumGenesisSpec)
+		name            string
+		chainID         string
+		outputPath      string
+		expectedBalance string
+		expectedChainID *big.Int
+		expectError     bool
+		validateGenesis func(t *testing.T, genesis *EthereumGenesisSpec)
 	}{
 		{
 			name:            "generate localnet genesis",
@@ -76,15 +76,15 @@ func TestGenerateEthereumGenesis(t *testing.T) {
 				assert.Equal(t, uint64(0), *genesis.Config.ShanghaiTime)
 				assert.NotNil(t, genesis.Config.CancunTime)
 				assert.Equal(t, uint64(0), *genesis.Config.CancunTime)
-				
+
 				// Validate genesis parameters
 				assert.Equal(t, "0x0", genesis.Nonce)
 				assert.Equal(t, "0x0", genesis.Timestamp)
 				assert.Equal(t, "0x1c9c380", genesis.GasLimit)
 				assert.Equal(t, "0x0", genesis.Difficulty)
-				
+
 				// Validate alloc
-				fundedAddr := "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
+				fundedAddr := DefaultFundedAddress
 				account, exists := genesis.Alloc[fundedAddr]
 				assert.True(t, exists)
 				assert.Equal(t, "10000000000000000000000000", account.Balance)
@@ -100,9 +100,9 @@ func TestGenerateEthereumGenesis(t *testing.T) {
 			validateGenesis: func(t *testing.T, genesis *EthereumGenesisSpec) {
 				// Validate chain ID
 				assert.Equal(t, big.NewInt(124864), genesis.Config.ChainID)
-				
+
 				// Validate devnet specific balance
-				fundedAddr := "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
+				fundedAddr := DefaultFundedAddress
 				account, exists := genesis.Alloc[fundedAddr]
 				assert.True(t, exists)
 				assert.Equal(t, "999000000000000000000000000", account.Balance)

--- a/cmd/mitosisd/cmd/eth_genesis_test.go
+++ b/cmd/mitosisd/cmd/eth_genesis_test.go
@@ -78,16 +78,27 @@ func TestGenerateEthereumGenesis(t *testing.T) {
 				assert.Equal(t, uint64(0), *genesis.Config.CancunTime)
 
 				// Validate genesis parameters
-				assert.Equal(t, "0x0", genesis.Nonce)
-				assert.Equal(t, "0x0", genesis.Timestamp)
-				assert.Equal(t, "0x1c9c380", genesis.GasLimit)
-				assert.Equal(t, "0x0", genesis.Difficulty)
+				assert.Equal(t, "0", genesis.Nonce)
+				assert.Equal(t, "0", genesis.Timestamp)
+				assert.Equal(t, "30000000", genesis.GasLimit)
+				assert.Equal(t, "0", genesis.Difficulty)
+
+				// Validate blob schedule
+				assert.NotNil(t, genesis.Config.BlobSchedule)
+				assert.NotNil(t, genesis.Config.BlobSchedule.Cancun)
+				assert.Equal(t, 3, genesis.Config.BlobSchedule.Cancun.Target)
+				assert.Equal(t, 6, genesis.Config.BlobSchedule.Cancun.Max)
+				assert.Equal(t, 3338477, genesis.Config.BlobSchedule.Cancun.BaseFeeUpdateFraction)
+				assert.NotNil(t, genesis.Config.BlobSchedule.Prague)
+				assert.Equal(t, 6, genesis.Config.BlobSchedule.Prague.Target)
+				assert.Equal(t, 9, genesis.Config.BlobSchedule.Prague.Max)
+				assert.Equal(t, 5007716, genesis.Config.BlobSchedule.Prague.BaseFeeUpdateFraction)
 
 				// Validate alloc
 				fundedAddr := DefaultFundedAddress
 				account, exists := genesis.Alloc[fundedAddr]
 				assert.True(t, exists)
-				assert.Equal(t, "10000000000000000000000000", account.Balance)
+				assert.Equal(t, "999000000000000000000000000", account.Balance)
 			},
 		},
 		{

--- a/cmd/mitosisd/cmd/init.go
+++ b/cmd/mitosisd/cmd/init.go
@@ -39,13 +39,13 @@ const (
 )
 
 type printInfo struct {
-	Moniker       string          `json:"moniker" yaml:"moniker"`
-	ChainID       string          `json:"chain_id" yaml:"chain_id"`
-	NodeID        string          `json:"node_id" yaml:"node_id"`
-	GenTxsDir     string          `json:"gentxs_dir" yaml:"gentxs_dir"`
-	AppMessage    json.RawMessage `json:"app_message" yaml:"app_message"`
-	EthGenesis    string          `json:"eth_genesis_path" yaml:"eth_genesis_path"`
-	EthChainID    string          `json:"eth_chain_id" yaml:"eth_chain_id"`
+	Moniker    string          `json:"moniker" yaml:"moniker"`
+	ChainID    string          `json:"chain_id" yaml:"chain_id"`
+	NodeID     string          `json:"node_id" yaml:"node_id"`
+	GenTxsDir  string          `json:"gentxs_dir" yaml:"gentxs_dir"`
+	AppMessage json.RawMessage `json:"app_message" yaml:"app_message"`
+	EthGenesis string          `json:"eth_genesis_path" yaml:"eth_genesis_path"`
+	EthChainID string          `json:"eth_chain_id" yaml:"eth_chain_id"`
 }
 
 func newPrintInfoWithEth(moniker, chainID, nodeID, genTxsDir string, appMessage json.RawMessage, ethGenesisPath string, ethChainID string) printInfo {
@@ -179,7 +179,7 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 
 			// Get Ethereum chain ID for display
 			ethChainID := GetEthChainIDFromCosmosChainID(chainID)
-			
+
 			toPrint := newPrintInfoWithEth(config.Moniker, chainID, nodeID, "", appState, ethGenesisPath, ethChainID.String())
 
 			cfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)

--- a/cmd/mitosisd/cmd/init.go
+++ b/cmd/mitosisd/cmd/init.go
@@ -39,20 +39,24 @@ const (
 )
 
 type printInfo struct {
-	Moniker    string          `json:"moniker" yaml:"moniker"`
-	ChainID    string          `json:"chain_id" yaml:"chain_id"`
-	NodeID     string          `json:"node_id" yaml:"node_id"`
-	GenTxsDir  string          `json:"gentxs_dir" yaml:"gentxs_dir"`
-	AppMessage json.RawMessage `json:"app_message" yaml:"app_message"`
+	Moniker       string          `json:"moniker" yaml:"moniker"`
+	ChainID       string          `json:"chain_id" yaml:"chain_id"`
+	NodeID        string          `json:"node_id" yaml:"node_id"`
+	GenTxsDir     string          `json:"gentxs_dir" yaml:"gentxs_dir"`
+	AppMessage    json.RawMessage `json:"app_message" yaml:"app_message"`
+	EthGenesis    string          `json:"eth_genesis_path" yaml:"eth_genesis_path"`
+	EthChainID    string          `json:"eth_chain_id" yaml:"eth_chain_id"`
 }
 
-func newPrintInfo(moniker, chainID, nodeID, genTxsDir string, appMessage json.RawMessage) printInfo {
+func newPrintInfoWithEth(moniker, chainID, nodeID, genTxsDir string, appMessage json.RawMessage, ethGenesisPath string, ethChainID string) printInfo {
 	return printInfo{
 		Moniker:    moniker,
 		ChainID:    chainID,
 		NodeID:     nodeID,
 		GenTxsDir:  genTxsDir,
 		AppMessage: appMessage,
+		EthGenesis: ethGenesisPath,
+		EthChainID: ethChainID,
 	}
 }
 
@@ -167,7 +171,16 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				return errorsmod.Wrap(err, "Failed to export genesis file")
 			}
 
-			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)
+			// Generate Ethereum genesis file
+			ethGenesisPath := filepath.Join(config.RootDir, "config", "eth_genesis.json")
+			if err = GenerateEthereumGenesis(chainID, ethGenesisPath); err != nil {
+				return errorsmod.Wrap(err, "Failed to generate Ethereum genesis file")
+			}
+
+			// Get Ethereum chain ID for display
+			ethChainID := GetEthChainIDFromCosmosChainID(chainID)
+			
+			toPrint := newPrintInfoWithEth(config.Moniker, chainID, nodeID, "", appState, ethGenesisPath, ethChainID.String())
 
 			cfg.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)
 			return displayInfo(toPrint)

--- a/cmd/mitosisd/cmd/init.go
+++ b/cmd/mitosisd/cmd/init.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 
@@ -36,6 +37,12 @@ const (
 
 	// FlagDefaultBondDenom defines the default denom to use in the genesis file.
 	FlagDefaultBondDenom = "default-denom"
+
+	// Ethereum genesis flags
+	FlagEthChainID     = "eth-chain-id"
+	FlagEthGasLimit    = "eth-gas-limit"
+	FlagEthFundedAddr  = "eth-funded-address"
+	FlagEthInitBalance = "eth-initial-balance"
 )
 
 type printInfo struct {
@@ -171,14 +178,39 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 				return errorsmod.Wrap(err, "Failed to export genesis file")
 			}
 
-			// Generate Ethereum genesis file
+			// Generate Ethereum genesis file with custom options
 			ethGenesisPath := filepath.Join(config.RootDir, "config", "eth_genesis.json")
-			if err = GenerateEthereumGenesis(chainID, ethGenesisPath); err != nil {
+
+			// Get CLI flag values for Ethereum genesis customization
+			ethChainIDFlag, _ := cmd.Flags().GetInt64(FlagEthChainID)
+			ethGasLimit, _ := cmd.Flags().GetUint64(FlagEthGasLimit)
+			ethFundedAddr, _ := cmd.Flags().GetString(FlagEthFundedAddr)
+			ethInitBalance, _ := cmd.Flags().GetString(FlagEthInitBalance)
+
+			opts := EthGenesisOptions{
+				ChainID:        chainID,
+				OutputPath:     ethGenesisPath,
+				GasLimit:       ethGasLimit,
+				FundedAddress:  ethFundedAddr,
+				InitialBalance: ethInitBalance,
+			}
+
+			// Set custom Ethereum chain ID if provided
+			if ethChainIDFlag > 0 {
+				opts.EthChainID = big.NewInt(ethChainIDFlag)
+			}
+
+			if err = GenerateEthereumGenesisWithOptions(opts); err != nil {
 				return errorsmod.Wrap(err, "Failed to generate Ethereum genesis file")
 			}
 
 			// Get Ethereum chain ID for display
-			ethChainID := GetEthChainIDFromCosmosChainID(chainID)
+			var ethChainID *big.Int
+			if opts.EthChainID != nil {
+				ethChainID = opts.EthChainID
+			} else {
+				ethChainID = GetEthChainIDFromCosmosChainID(chainID)
+			}
 
 			toPrint := newPrintInfoWithEth(config.Moniker, chainID, nodeID, "", appState, ethGenesisPath, ethChainID.String())
 
@@ -193,6 +225,12 @@ func InitCmd(mbm module.BasicManager, defaultNodeHome string) *cobra.Command {
 	cmd.Flags().String(flags.FlagChainID, "", "genesis file chain-id, if left blank will be randomly created")
 	cmd.Flags().String(FlagDefaultBondDenom, "", "genesis file default denomination, if left blank default value is 'stake'")
 	cmd.Flags().Int64(flags.FlagInitHeight, 1, "specify the initial block height at genesis")
+
+	// Ethereum genesis flags
+	cmd.Flags().Int64(FlagEthChainID, 0, "ethereum chain ID (overrides default mapping)")
+	cmd.Flags().Uint64(FlagEthGasLimit, 0, "ethereum genesis gas limit (default: 30000000)")
+	cmd.Flags().String(FlagEthFundedAddr, "", "ethereum funded address (default: "+DefaultFundedAddress+")")
+	cmd.Flags().String(FlagEthInitBalance, "", "ethereum initial balance in wei (default: 999000000000000000000000000)")
 
 	return cmd
 }

--- a/cmd/mitosisd/cmd/init_test.go
+++ b/cmd/mitosisd/cmd/init_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPrintInfoWithEth(t *testing.T) {
+	moniker := "test-node"
+	chainID := "test-chain-1"
+	nodeID := "node123"
+	genTxsDir := "/path/to/gentxs"
+	appMessage := json.RawMessage(`{"test": "message"}`)
+	ethGenesisPath := "/path/to/eth_genesis.json"
+	ethChainID := "12345"
+
+	info := newPrintInfoWithEth(moniker, chainID, nodeID, genTxsDir, appMessage, ethGenesisPath, ethChainID)
+
+	assert.Equal(t, moniker, info.Moniker)
+	assert.Equal(t, chainID, info.ChainID)
+	assert.Equal(t, nodeID, info.NodeID)
+	assert.Equal(t, genTxsDir, info.GenTxsDir)
+	assert.Equal(t, appMessage, info.AppMessage)
+	assert.Equal(t, ethGenesisPath, info.EthGenesis)
+	assert.Equal(t, ethChainID, info.EthChainID)
+}
+
+func TestDisplayInfo(t *testing.T) {
+	info := printInfo{
+		Moniker:    "test-node",
+		ChainID:    "test-chain",
+		NodeID:     "node123",
+		GenTxsDir:  "/gentxs",
+		AppMessage: json.RawMessage(`{"msg": "test"}`),
+		EthGenesis: "/eth_genesis.json",
+		EthChainID: "12345",
+	}
+
+	// Redirect stderr to capture output
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	err := displayInfo(info)
+	require.NoError(t, err)
+
+	// Restore stderr
+	w.Close()
+	os.Stderr = oldStderr
+
+	// Read captured output
+	out := make([]byte, 1024)
+	n, _ := r.Read(out)
+	
+	// Verify JSON output contains expected fields
+	var parsed printInfo
+	err = json.Unmarshal(out[:n], &parsed)
+	require.NoError(t, err)
+	
+	// Compare fields individually to avoid JSON formatting differences
+	assert.Equal(t, info.Moniker, parsed.Moniker)
+	assert.Equal(t, info.ChainID, parsed.ChainID)
+	assert.Equal(t, info.NodeID, parsed.NodeID)
+	assert.Equal(t, info.GenTxsDir, parsed.GenTxsDir)
+	assert.Equal(t, info.EthGenesis, parsed.EthGenesis)
+	assert.Equal(t, info.EthChainID, parsed.EthChainID)
+	
+	// For AppMessage, compare the content after parsing
+	var expectedMsg, actualMsg map[string]interface{}
+	json.Unmarshal(info.AppMessage, &expectedMsg)
+	json.Unmarshal(parsed.AppMessage, &actualMsg)
+	assert.Equal(t, expectedMsg, actualMsg)
+}
+
+func TestGenerateEthereumGenesis_Integration(t *testing.T) {
+	// This tests the integration between init.go and eth_genesis.go
+	tempDir := t.TempDir()
+	
+	tests := []struct {
+		name           string
+		chainID        string
+		expectedEthID  int64
+		expectedBalance string
+	}{
+		{
+			name:           "localnet integration",
+			chainID:        "mitosis-localnet-1",
+			expectedEthID:  124899,
+			expectedBalance: "10000000000000000000000000",
+		},
+		{
+			name:           "devnet integration",
+			chainID:        "mitosis-devnet-1",
+			expectedEthID:  124864,
+			expectedBalance: "999000000000000000000000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ethGenesisPath := filepath.Join(tempDir, tt.chainID, "eth_genesis.json")
+			
+			// Test the function that would be called from InitCmd
+			err := GenerateEthereumGenesis(tt.chainID, ethGenesisPath)
+			require.NoError(t, err)
+
+			// Verify the file was created
+			data, err := os.ReadFile(ethGenesisPath)
+			require.NoError(t, err)
+
+			var genesis EthereumGenesisSpec
+			err = json.Unmarshal(data, &genesis)
+			require.NoError(t, err)
+
+			// Verify chain ID mapping
+			assert.Equal(t, tt.expectedEthID, genesis.Config.ChainID.Int64())
+			
+			// Verify balance
+			fundedAddr := "0x2FB9C04d3225b55C964f9ceA934Cc8cD6070a3fF"
+			account, exists := genesis.Alloc[fundedAddr]
+			require.True(t, exists)
+			assert.Equal(t, tt.expectedBalance, account.Balance)
+		})
+	}
+}
+
+func TestEthChainIDMapping(t *testing.T) {
+	// Test the chain ID mapping used in InitCmd
+	tests := []struct {
+		cosmosChainID string
+		expectedEthID int64
+	}{
+		{"mitosis-localnet-1", 124899},
+		{"mitosis-devnet-1", 124864},
+		{"custom-chain", 100000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.cosmosChainID, func(t *testing.T) {
+			ethChainID := GetEthChainIDFromCosmosChainID(tt.cosmosChainID)
+			assert.Equal(t, tt.expectedEthID, ethChainID.Int64())
+		})
+	}
+}
+
+func TestInitCmd_EthGenesisCreation(t *testing.T) {
+	// Test that init command would create eth genesis in the right location
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "config")
+	
+	// Create config directory (simulating what InitCmd would do)
+	err := os.MkdirAll(configDir, 0755)
+	require.NoError(t, err)
+
+	// Test eth genesis generation
+	ethGenesisPath := filepath.Join(configDir, "eth_genesis.json")
+	err = GenerateEthereumGenesis("test-chain", ethGenesisPath)
+	require.NoError(t, err)
+
+	// Verify file exists at expected location
+	_, err = os.Stat(ethGenesisPath)
+	require.NoError(t, err)
+
+	// Verify we can parse the genesis file
+	genesis, err := genutiltypes.AppGenesisFromFile(filepath.Join(configDir, "genesis.json"))
+	if err == nil {
+		// If cosmos genesis exists, verify it has the right structure
+		assert.NotNil(t, genesis)
+	}
+}

--- a/cmd/mitosisd/cmd/init_test.go
+++ b/cmd/mitosisd/cmd/init_test.go
@@ -94,7 +94,7 @@ func TestGenerateEthereumGenesis_Integration(t *testing.T) {
 			name:            "localnet integration",
 			chainID:         "mitosis-localnet-1",
 			expectedEthID:   124899,
-			expectedBalance: "10000000000000000000000000",
+			expectedBalance: "999000000000000000000000000",
 		},
 		{
 			name:            "devnet integration",


### PR DESCRIPTION
- Introduced a new file `eth_genesis.go` to handle Ethereum genesis file creation.
- Implemented `GenerateEthereumGenesis` function to generate a genesis file based on Cosmos chain ID.
- Updated `printInfo` struct to include Ethereum genesis path and chain ID.
- Modified `InitCmd` to generate the Ethereum genesis file during initialization.

This addition enhances the integration of Ethereum functionalities within the Mitosis chain, allowing for seamless genesis file generation.