### PR TITLE
fix(mito): use injected build version for mito version command

### DIFF
--- a/cmd/mito/commands/version/version.go
+++ b/cmd/mito/commands/version/version.go
@@ -3,14 +3,8 @@ package version
 import (
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/version"
 	"github.com/spf13/cobra"
-)
-
-// Version information
-var (
-	Version   = "0.0.1"
-	GitCommit = "unknown"
-	BuildDate = "unknown"
 )
 
 // NewVersionCmd returns the version command
@@ -20,9 +14,9 @@ func NewVersionCmd() *cobra.Command {
 		Short: "Show version information",
 		Long:  "Display version, git commit, and build date information",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("mito version %s\n", Version)
-			fmt.Printf("Git commit: %s\n", GitCommit)
-			fmt.Printf("Build date: %s\n", BuildDate)
+			fmt.Printf("mito version %s\n", version.Version)
+			fmt.Printf("Git commit: %s\n", version.Commit)
+			fmt.Printf("Build date: %s\n", version.BuildTags)
 		},
 	}
 


### PR DESCRIPTION
- Remove hardcoded version, commit, and build date from cmd/mito/commands/version/version.go
- Use Cosmos SDK's injected version.Version, version.Commit, and version.BuildTags for accurate version info at build time
- Ensures mito version command always reflects the actual release version and commit