### PR TITLE
Suggest PGP encryption for secure vulnerability reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,10 @@ Instead, please report them via one of the following methods:
 1. **Email**: Send details to [security@mitosis.org](mailto:security@mitosis.org)
 2. **GitHub Security Advisories**: Use the [private vulnerability reporting feature](https://github.com/mitosis-org/chain/security/advisories/new)
 
+> 🔐 **Optional:** If your report contains sensitive information, we recommend encrypting it using PGP.  
+> Currently, no public key is provided — consider publishing one to enable secure disclosure.
+
+
 ### What to Include
 
 When reporting a vulnerability, please include:


### PR DESCRIPTION
This PR suggests adding a short note recommending the use of PGP encryption for sensitive vulnerability reports submitted via email.

Currently, no public key is available, the note includes a suggestion to consider publishing one in the future to support secure disclosure.

This change is a small improvement to align with common security best practices and is meant as a contribution suggestion to improve the disclosure process.

Happy to revise or remove if the team prefers a different approach. Appreciate your work on Mitosis!
