### PR TITLE
chore: fix inconsistent function name in comment

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -33,7 +33,7 @@ func (app *MitosisApp) setupUpgradeHandlers() {
 	}
 }
 
-// setUpgradeStoreLoaders sets custom store loaders to customize the rootMultiStore
+// setupUpgradeStoreLoaders sets custom store loaders to customize the rootMultiStore
 // initialization for software upgrades.
 func (app *MitosisApp) setupUpgradeStoreLoaders() {
 	upgradeInfo, err := app.UpgradeKeeper.ReadUpgradeInfoFromDisk()


### PR DESCRIPTION
fix inconsistent function name in comment